### PR TITLE
Add overlapped srun commands for Slurm Ray jobs

### DIFF
--- a/nemo_run/run/ray/slurm.py
+++ b/nemo_run/run/ray/slurm.py
@@ -117,6 +117,7 @@ class SlurmRayRequest:
     command: Optional[str] = None
     workdir: Optional[str] = None
     nemo_run_dir: Optional[str] = None
+    command_groups: Optional[list[list[str]]] = None
     launch_cmd: list[str]
 
     @staticmethod
@@ -233,6 +234,67 @@ class SlurmRayRequest:
             "command_workdir": self.workdir,
             "gres_specification": get_gres_specification(),
         }
+
+        if self.command_groups:
+            srun_commands: list[str] = []
+            group_env_vars: list[list[str]] = []
+
+            def _get_container_flags(mounts: list[str], container_image: Optional[str]) -> list[str]:
+                _flags = ["--container-image", container_image] if container_image else []
+                new_mounts = copy.deepcopy(mounts)
+                if self.nemo_run_dir:
+                    for i, mnt in enumerate(new_mounts):
+                        if mnt.startswith(RUNDIR_SPECIAL_NAME):
+                            new_mounts[i] = mnt.replace(RUNDIR_SPECIAL_NAME, self.nemo_run_dir, 1)
+                    new_mounts.append(f"{self.nemo_run_dir}:/{RUNDIR_NAME}")
+                new_mounts.append(f"{self.cluster_dir}:{self.cluster_dir}")
+                _flags += ["--container-mounts", ",".join(new_mounts)]
+                container_workdir = self.workdir or self.cluster_dir
+                _flags += ["--container-workdir", container_workdir]
+                return _flags
+
+            for idx, group in enumerate(self.command_groups):
+                if self.executor.run_as_group and len(self.executor.resource_group) == len(self.command_groups):
+                    req = self.executor.resource_group[idx]
+                    env_list = [f"export {k.upper()}={v}" for k, v in req.env_vars.items()]
+                    group_env_vars.append(env_list)
+                    container_flags = _get_container_flags(req.container_mounts, req.container_image)
+                    srun_args = ["--wait=60", "--kill-on-bad-exit=1", "--overlap"]
+                    srun_args.extend(req.srun_args or [])
+                else:
+                    container_flags = _get_container_flags(self.executor.container_mounts, self.executor.container_image)
+                    srun_args = ["--wait=60", "--kill-on-bad-exit=1", "--overlap"]
+                    srun_args.extend(self.executor.srun_args or [])
+                    group_env_vars.append([])
+
+                stdout_path = os.path.join(self.cluster_dir, "logs", f"ray-overlap-{idx}.out")
+                stderr_flags = []
+                if not self.executor.stderr_to_stdout:
+                    stderr_flags = ["--error", os.path.join(self.cluster_dir, "logs", f"ray-overlap-{idx}.err")]
+
+                srun_cmd = " ".join(
+                    list(
+                        map(
+                            lambda arg: arg if isinstance(arg, noquote) else shlex.quote(arg),
+                            [
+                                "srun",
+                                "--output",
+                                noquote(stdout_path),
+                                *stderr_flags,
+                                *container_flags,
+                                *srun_args,
+                            ],
+                        )
+                    )
+                )
+                command = " ".join(group)
+                if self.executor.run_as_group:
+                    srun_commands.append(f"{srun_cmd} {command} & pids[{idx}]=$!")
+                else:
+                    srun_commands.append(f"{srun_cmd} {command}")
+
+            vars_to_fill["srun_commands"] = srun_commands
+            vars_to_fill["group_env_vars"] = group_env_vars
 
         if self.pre_ray_start_commands:
             vars_to_fill["pre_ray_start_commands"] = "\n".join(self.pre_ray_start_commands)
@@ -398,6 +460,7 @@ Useful Commands
         dryrun: bool = False,
         command: Optional[str] = None,
         workdir: Optional[str] = None,
+        command_groups: Optional[list[list[str]]] = None,
     ) -> Any:
         """Create (or reuse) a Slurm-backed Ray cluster and return its job-id.
 
@@ -416,6 +479,9 @@ Useful Commands
             Optional command executed after the Ray head node is ready (e.g. ``ray job submit``).
         workdir : str | None
             Remote working directory that becomes the CWD inside the container.
+        command_groups : list[list[str]] | None
+            Additional commands (one per group) executed via ``srun`` with ``--overlap``
+            after the cluster is started.
 
         Returns
         -------
@@ -433,6 +499,7 @@ Useful Commands
             pre_ray_start_commands=pre_ray_start_commands,
             command=command,
             workdir=workdir,
+            command_groups=command_groups,
             launch_cmd=["sbatch", "--requeue", "--parsable", "--dependency=singleton"],
         ).materialize()
 
@@ -1094,6 +1161,7 @@ Useful Commands (to be run on the login node of the Slurm cluster)
         runtime_env_yaml: Optional[str] | None = None,
         pre_ray_start_commands: Optional[list[str]] = None,
         dryrun: bool = False,
+        command_groups: Optional[list[list[str]]] = None,
     ):
         """Submit a Ray job via Slurm and return a *live* SlurmRayJob helper.
 
@@ -1106,6 +1174,7 @@ Useful Commands (to be run on the login node of the Slurm cluster)
                 executor=my_slurm_executor,
                 command="python train.py",
                 workdir="./src",
+                command_groups=[["echo", "hello"]],
             )
         """
         # ------------------------------------------------------------------
@@ -1212,6 +1281,7 @@ Useful Commands (to be run on the login node of the Slurm cluster)
             dryrun=dryrun,
             command=command,
             workdir=remote_workdir,
+            command_groups=command_groups,
         )
 
         self.job_id = job_id

--- a/nemo_run/run/ray/templates/ray.sub.j2
+++ b/nemo_run/run/ray/templates/ray.sub.j2
@@ -296,6 +296,16 @@ echo "[INFO] Ray cluster information saved to $CLUSTER_DIR/ray_cluster_info.json
 ########################################################
 
 # We can now launch a job on this cluster
+{% if srun_commands %}
+{% for srun_command in srun_commands %}
+{%- if loop.index <= group_env_vars|length %}
+{% for env_var in group_env_vars[loop.index - 1] %}
+{{env_var}}
+{% endfor %}
+{%- endif %}
+{{srun_command}}
+{% endfor %}
+{% endif %}
 # We do so by launching a driver process on the physical node that the head node is on
 # This driver process is responsible for launching a job on the Ray cluster
 CONTAINER_CWD=$(scontrol show job $SLURM_JOB_ID --json | jq -r '.jobs[].current_working_directory')


### PR DESCRIPTION
## Summary
- allow SlurmRayRequest to accept command groups
- build srun command lines with overlap flags
- expose `command_groups` through SlurmRayCluster and SlurmRayJob
- run additional srun commands in ray.sub.j2 template

## Testing
- `pre-commit run --files nemo_run/run/ray/slurm.py nemo_run/run/ray/templates/ray.sub.j2` *(fails: error 403 during hook installation)*
- `pytest -k nothing` *(fails: pyenv python version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68427f0ec62483278989dbe05518ef86